### PR TITLE
Fix bug regarding static stability constraints.

### DIFF
--- a/src/problem.impl.cc
+++ b/src/problem.impl.cc
@@ -75,7 +75,7 @@ namespace hpp {
         {
           NamedConstraints_t constraints;
           std::vector <NumericalConstraintPtr_t> numericalConstraints =
-            createSlidingStabilityConstraint (robot, comc,
+            createAlignedCOMStabilityConstraint (robot, comc,
                 leftAnkle, rightAnkle, *config);
           std::string p (prefix);
           constraints.push_back (NamedConstraint_t


### PR DESCRIPTION
Both ALIGNED_COM and SLIDING static stability types were generating the same set of constraints.